### PR TITLE
Return a randomly generated cat fact to `/facts` route and cat breed to `/breeds` route

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,8 +1,39 @@
 from fastapi import FastAPI
+import requests
+import random
 
 app = FastAPI()
 
 
+# Homepage. Directs you to '/facts' page or '/breeds' page, where either you get a cat fact pulled from the
+# catfact.ninja 'facts' get request, or a breed from the 'breeds' get request"
+# https://catfact.ninja/#/
 @app.get("/")
 async def root():
-    return {"message": "Hello World"}
+    return "Random fact (from a list) generated at '/facts'. Random breed generated at '/breeds'."
+
+
+# Returns a random cat fact from a list of facts (default length of 10 facts)
+@app.get("/facts")
+async def root():
+    # URL to send an HTTP get request to
+    resp = requests.get("https://catfact.ninja/facts").json()
+
+    # response, after .json conversion, is a dictionary containing data of interest under key "data", and facts in their own dictionary under key "fact"
+    facts = resp["data"]
+    fact = random.choice(facts)["fact"]
+
+    return fact
+
+
+# Returns a cat breed from a list dictionaries featuring breeds and other information
+@app.get("/breeds")
+async def root():
+    # URL to send an HTTP get request to
+    resp = requests.get("https://catfact.ninja/breeds").json()
+
+    # response, after .json conversion, is a dictionary containing data of interest under key "data", and breeds in their own dictionary under key "breed"
+    cat_info = resp["data"]
+    breed = random.choice(cat_info)["breed"]
+
+    return breed

--- a/main.py
+++ b/main.py
@@ -17,23 +17,35 @@ async def root():
 @app.get("/facts")
 async def get_cat_facts():
     # URL to send an HTTP get request to
-    resp = requests.get("https://catfact.ninja/facts").json()
+    resp = requests.get("https://catfact.ninja/facts")
 
+    # I believe this allows 200-series codes & 300-series codes
+    try: resp.raise_for_status()
+    except HTTPError:
+        return {"error": resp.reason, "status_code": resp.status_code}
+    
     # response, after .json conversion, is a dictionary containing data of interest under key "data", and facts in their own dictionary under key "fact"
+    resp = resp.json()
     facts = resp["data"]
     fact = random.choice(facts)["fact"]
 
-    return fact
+    return {"fact": fact}
 
 
 # Returns a cat breed from a list dictionaries featuring breeds and other information
 @app.get("/breeds")
 async def get_cat_breeds():
     # URL to send an HTTP get request to
-    resp = requests.get("https://catfact.ninja/breeds").json()
+    resp = requests.get("https://catfact.ninja/breeds")
 
+    # I believe this allows 200-series codes & 300-series codes
+    try: resp.raise_for_status()
+    except HTTPError:
+        return {"error": resp.reason, "status_code": resp.status_code}
+    
     # response, after .json conversion, is a dictionary containing data of interest under key "data", and breeds in their own dictionary under key "breed"
+    resp = resp.json()
     cat_info = resp["data"]
     breed = random.choice(cat_info)["breed"]
 
-    return breed
+    return {"breed": breed}

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ async def root():
 
 # Returns a random cat fact from a list of facts (default length of 10 facts)
 @app.get("/facts")
-async def root():
+async def get_cat_facts():
     # URL to send an HTTP get request to
     resp = requests.get("https://catfact.ninja/facts").json()
 
@@ -28,7 +28,7 @@ async def root():
 
 # Returns a cat breed from a list dictionaries featuring breeds and other information
 @app.get("/breeds")
-async def root():
+async def get_cat_breeds():
     # URL to send an HTTP get request to
     resp = requests.get("https://catfact.ninja/breeds").json()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi[standard] == 0.114.0
 pytest == 8.3.2
 black == 24.8.0
+requests == 2.32.3

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,5 +1,6 @@
 import main
 
+
 # check that root() has a return value
 def test_main():
     assert main.root()


### PR DESCRIPTION
Adding a /facts (`localhost:8080/facts`) and /breeds (`localhost:8080/breeds`) route, which generate random cat facts and breeds, respectively, using catfacts.ninja API and the method you outlined on Friday.

At the /facts route, the [facts](https://catfact.ninja/#/Facts/getFacts) get request is used, returning a list of facts, and python's `random.choice()` is used to pick one from the list to be displayed on the webpage.
![image](https://github.com/user-attachments/assets/c6b255e1-32a9-4939-b1fc-b9a5b3f2ba12)

At the /breeds route, the [breeds](https://catfact.ninja/#/Breeds/getBreeds) get request is used, and returns a list of dictionaries containing cat breed, country, origin, coat and pattern information. Again, 1 option is selected with `random.choice()` and its breed is displayed on the webpage.
![image](https://github.com/user-attachments/assets/eed72bb2-6f2c-4e48-8cce-ecaad571c41f)
